### PR TITLE
Varia: Fix Interpolation issue in comment-meta style

### DIFF
--- a/varia/sass/components/comments/_comments.scss
+++ b/varia/sass/components/comments/_comments.scss
@@ -79,7 +79,7 @@
 
 	$avatar-size: #{map-deep-get($config-global, "spacing", "vertical")};
 
-	margin-right: calc( $avatar-size + (0.5 * #{map-deep-get($config-global, "spacing", "horizontal")}) );
+	margin-right: calc( #{$avatar-size} + (0.5 * #{map-deep-get($config-global, "spacing", "horizontal")}) );
 
 	.comment-author {
 		line-height: #{map-deep-get($config-global, "font", "line-height", "heading")};

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3332,7 +3332,7 @@ body:not(.fse-enabled) .footer-menu a {
  * Comment Meta
  */
 .comment-meta {
-	margin-left: calc( $avatar-size + (0.5 * 16px));
+	margin-left: calc( 32px + (0.5 * 16px));
 }
 
 .comment-meta .comment-author {

--- a/varia/style.css
+++ b/varia/style.css
@@ -3349,7 +3349,7 @@ body:not(.fse-enabled) .footer-menu a {
  * Comment Meta
  */
 .comment-meta {
-	margin-right: calc( $avatar-size + (0.5 * 16px));
+	margin-right: calc( 32px + (0.5 * 16px));
 }
 
 .comment-meta .comment-author {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
There is an Interpolation issue in comment-meta style. Basically It has no visual effect, it just produces incorrect CSS because of not using proper Interpolation in SASS files!
This PR fixes it.

**Before Fix(Invalid CSS)**
![image](https://user-images.githubusercontent.com/12055657/81377312-0ad98100-9127-11ea-9944-90fcc6dcc70f.png)

**After Fix(Valid CSS, though not applying)**
![image](https://user-images.githubusercontent.com/12055657/81393094-89431c80-9141-11ea-8c6b-9c6c66779875.png)

#### Related issue(s):
None
