### PR TITLE
Varia : Fixes Comment avatar on amp pages

### DIFF
--- a/varia/sass/components/comments/_comments.scss
+++ b/varia/sass/components/comments/_comments.scss
@@ -144,7 +144,7 @@
 			.avatar {
 				margin-right: #{map-deep-get($config-global, "spacing", "horizontal")};
 				display: inherit;
-				position: inherit;
+				position: relative;
 				right: inherit;
 			}
 		}

--- a/varia/style.css
+++ b/varia/style.css
@@ -3418,7 +3418,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Varia Theme : Fixes Comment avatar size for AMP pages on iPad.

Before on iPad AMP | After on iPad AMP
------------ | -------------
![image](https://user-images.githubusercontent.com/1132541/81372719-ae6f6500-9118-11ea-81b1-7c48c1fe8fa5.png) | ![image](https://user-images.githubusercontent.com/1132541/81372899-19b93700-9119-11ea-8e79-ff4e6751d4bb.png)

Before on iPad Non AMP | After on iPad Non AMP
------------ | -------------
![image](https://user-images.githubusercontent.com/1132541/81373180-c2679680-9119-11ea-96b9-324c4f487ee4.png) | ![image](https://user-images.githubusercontent.com/1132541/81373277-f6db5280-9119-11ea-9e01-a2f6ec42a9a7.png)






