### PR TITLE
Rivington: Fix text showing issue in tables with Stripes style

### DIFF
--- a/rivington/sass/_extra-child-theme.scss
+++ b/rivington/sass/_extra-child-theme.scss
@@ -345,6 +345,22 @@ a {
 	}
 }
 
+// Table with Stripes style
+.wp-block-table.is-style-stripes {
+	border-spacing: 0;
+	border-collapse: inherit;
+	background-color: transparent;
+	border-bottom: 1px solid #f3f4f5;
+
+	tbody tr:nth-child(odd), &.has-subtle-light-gray-background-color tbody tr:nth-child(odd) {
+		background-color: $color_background;
+	}
+
+	th, td {
+		border-color: transparent;
+	}
+}
+
 /**
  * Widgets
  */

--- a/rivington/sass/style-child-theme-editor.scss
+++ b/rivington/sass/style-child-theme-editor.scss
@@ -130,3 +130,18 @@ $font_size_md: map-deep-get($config-global, "font", "size", "md");
 .wp-block-a8c-blog-posts + .button {
 	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
 }
+
+// Table with Stripes style
+.wp-block-table.is-style-stripes {
+	border-spacing: 0;
+	border-collapse: inherit;
+	background-color: transparent;
+
+	tbody tr:nth-child(odd), &.has-subtle-light-gray-background-color tbody tr:nth-child(odd) {
+		background-color: #060f29;
+	}
+
+	th, td {
+		border-color: transparent;
+	}
+}

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1358,3 +1358,17 @@ table th,
 .wp-block-a8c-blog-posts + .button {
 	font-size: 1em;
 }
+
+.wp-block-table.is-style-stripes {
+	border-spacing: 0;
+	border-collapse: inherit;
+	background-color: transparent;
+}
+
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd), .wp-block-table.is-style-stripes.has-subtle-light-gray-background-color tbody tr:nth-child(odd) {
+	background-color: #060f29;
+}
+
+.wp-block-table.is-style-stripes th, .wp-block-table.is-style-stripes td {
+	border-color: transparent;
+}

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -4266,6 +4266,21 @@ p:not(.site-title) a:hover {
 	text-decoration: underline;
 }
 
+.wp-block-table.is-style-stripes {
+	border-spacing: 0;
+	border-collapse: inherit;
+	background-color: transparent;
+	border-bottom: 1px solid #f3f4f5;
+}
+
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd), .wp-block-table.is-style-stripes.has-subtle-light-gray-background-color tbody tr:nth-child(odd) {
+	background-color: #060f29;
+}
+
+.wp-block-table.is-style-stripes th, .wp-block-table.is-style-stripes td {
+	border-color: transparent;
+}
+
 /**
  * Widgets
  */

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -4295,6 +4295,21 @@ p:not(.site-title) a:hover {
 	text-decoration: underline;
 }
 
+.wp-block-table.is-style-stripes {
+	border-spacing: 0;
+	border-collapse: inherit;
+	background-color: transparent;
+	border-bottom: 1px solid #f3f4f5;
+}
+
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd), .wp-block-table.is-style-stripes.has-subtle-light-gray-background-color tbody tr:nth-child(odd) {
+	background-color: #060f29;
+}
+
+.wp-block-table.is-style-stripes th, .wp-block-table.is-style-stripes td {
+	border-color: transparent;
+}
+
 /**
  * Widgets
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds styling for tables with `Stripes` style in both Block editor and Frontend, so that the texts are visible.

**After applying Fix in Block Editor**
![image](https://user-images.githubusercontent.com/12055657/83749908-49128380-a686-11ea-965f-b55bfab30c3a.png)

**After applying Fix in frontend**
![image](https://user-images.githubusercontent.com/12055657/83750207-c807bc00-a686-11ea-9e92-b7d9e8e7b2e0.png)


#### Related issue(s):
Fixes #35 